### PR TITLE
Adapt convergence runscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Other runscripts:
   balance. No absorbing boundaries, just zero Dirichlet.
 
 ## Test setups for the absorbing boundary conditions (ABCs)
-
-Wave sent into an "empty" domain by a time dependent Dirichlet boundary condition:
-* [unit_test_3D_ABC](./unit_test_3D_ABC.py) is for running the 3D quasi-1D model with
-one absorbing boundary.
+The domain starts out empty and a wave propagates from west to east:
+* [runscript_dirichlet_wave.py](./run_simulations/runscript_dirichlet_wave.py) has a wave that is initiated by a time dependent Dirichlet condition on the west boundary
 
 The domain is fully filled with the wave and no energy is added to the system. 
 The only things driving the wave are initial values for displacement, velocity and acceleration:
 * [runscript_orthogonal.py](./run_simulations/runscript_orthogonal.py) is for running the 2D quasi-1D model with absorbing boundary on the west and east side. 
 * [runscript_diagonal.py](./run_simulations/runscript_diagonal.py) is for running a simulation with all absorbing boundaries. The wave is a rotation of the wave in [runscript_orthogonal.py](./run_simulations/runscript_orthogonal.py). 
+
+
 ## Verification setup for the dynamic momentum balance
 Convergence analysis is only done in 2D, but 3D should be no different. The setup is as
 follows:

--- a/manufactured_solution_dynamic.py
+++ b/manufactured_solution_dynamic.py
@@ -13,6 +13,7 @@ from models import MomentumBalanceTimeDepSource
 from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.utils.examples_utils import VerificationUtils
 from porepy.viz.data_saving_model_mixin import VerificationDataSaving
+from porepy.applications.convergence_analysis import ConvergenceAnalysis
 
 from utils import symbolic_representation
 from utils import symbolic_equation_terms
@@ -91,7 +92,7 @@ class ManuMechDataSaving(VerificationDataSaving):
         exact_displacement = self.exact_sol.displacement(sd=sd, time=t)
         displacement_ad = self.displacement([sd])
         approx_displacement = displacement_ad.evaluate(self.equation_system).val
-        error_displacement = pp.error_computation.l2_error(
+        error_displacement = ConvergenceAnalysis.l2_error(
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
@@ -103,7 +104,7 @@ class ManuMechDataSaving(VerificationDataSaving):
         exact_force = self.exact_sol.elastic_force(sd=sd, time=t)
         force_ad = self.stress([sd])
         approx_force = force_ad.evaluate(self.equation_system).val
-        error_force = pp.error_computation.l2_error(
+        error_force = ConvergenceAnalysis.l2_error(
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,

--- a/manufactured_solution_dynamic_3D.py
+++ b/manufactured_solution_dynamic_3D.py
@@ -13,6 +13,7 @@ from models import MomentumBalanceTimeDepSource
 from porepy.applications.md_grids.domains import nd_cube_domain
 from porepy.utils.examples_utils import VerificationUtils
 from porepy.viz.data_saving_model_mixin import VerificationDataSaving
+from porepy.applications.convergence_analysis import ConvergenceAnalysis
 
 from utils import symbolic_representation
 from utils import symbolic_equation_terms
@@ -91,7 +92,7 @@ class ManuMechDataSaving(VerificationDataSaving):
         exact_displacement = self.exact_sol.displacement(sd=sd, time=t)
         displacement_ad = self.displacement([sd])
         approx_displacement = displacement_ad.evaluate(self.equation_system).val
-        error_displacement = pp.error_computation.l2_error(
+        error_displacement = ConvergenceAnalysis.l2_error(
             grid=sd,
             true_array=exact_displacement,
             approx_array=approx_displacement,
@@ -103,7 +104,7 @@ class ManuMechDataSaving(VerificationDataSaving):
         exact_force = self.exact_sol.elastic_force(sd=sd, time=t)
         force_ad = self.stress([sd])
         approx_force = force_ad.evaluate(self.equation_system).val
-        error_force = pp.error_computation.l2_error(
+        error_force = ConvergenceAnalysis.l2_error(
             grid=sd,
             true_array=exact_force,
             approx_array=approx_force,

--- a/run_simulations/runscript_dirichlet_wave.py
+++ b/run_simulations/runscript_dirichlet_wave.py
@@ -3,6 +3,7 @@ import porepy as pp
 import numpy as np
 
 from model_one_orthogonal_wave import BaseScriptModel
+from porepy.applications.convergence_analysis import ConvergenceAnalysis
 
 from utils import get_boundary_cells
 from utils import u_v_a_wrap
@@ -165,7 +166,7 @@ class Exporting:
 
             u_h = np.reshape(u_h, (self.nd, sd.num_cells), "F")[0]
 
-            error = pp.error_computation.l2_error(
+            error = ConvergenceAnalysis.l2_error(
                 grid=sd,
                 true_array=u_e,
                 approx_array=u_h,


### PR DESCRIPTION
There was a slight change to how to utilize the l2 error computation within PorePy. This PR adapts the code accordingly. Missing update of readme file from previous PR is also covered.