### PR TITLE
Abc refactor 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ This might be deleted, but for now it's just hid within [verification](./verific
 ## Other
 [ParaView](./ParaView/) directory is mainly for .py scripts or .pvsm files for
 visualization in ParaView.
+
+### Known "bugs" or potential problems
+* Heterogeneous wave speed representation in cases where manufactured solutions are used.
+* Boundary condition methods might start acting weird in the case of intersecting fractures. Will fix when/if it becomes a problem.
+* Robin boundary conditions with the PorePy models are a bit ... yeah. Seek a permanent solution for that.

--- a/models/absorbing_boundary_conditions.py
+++ b/models/absorbing_boundary_conditions.py
@@ -199,8 +199,8 @@ class HelperMethodsABC:
         displacement = self.displacement(subdomains)
 
         boundary_displacement = (
-            discr.bound_displacement_cell @ displacement
-            + discr.bound_displacement_face @ bc
+            discr.bound_displacement_cell() @ displacement
+            + discr.bound_displacement_face() @ bc
         )
 
         boundary_displacement.set_name("boundary_displacement")
@@ -457,9 +457,9 @@ class BoundaryGridStuff:
         # subdomains, and let these act as Dirichlet boundary conditions on the
         # subdomains.
         stress = (
-            discr.stress @ self.displacement(domains)
-            + discr.bound_stress @ boundary_operator
-            + discr.bound_stress
+            discr.stress() @ self.displacement(domains)
+            + discr.bound_stress() @ boundary_operator
+            + discr.bound_stress()
             @ proj.mortar_to_primary_avg
             @ self.interface_displacement(interfaces)
         )
@@ -511,9 +511,9 @@ class BoundaryGridStuff:
         )
 
         # Compose operator.
-        div_u_integrated = discr.div_u @ self.displacement(
+        div_u_integrated = discr.div_u() @ self.displacement(
             subdomains
-        ) + discr.bound_div_u @ (
+        ) + discr.bound_div_u() @ (
             boundary_operator
             + sd_projection.face_restriction(subdomains)
             @ mortar_projection.mortar_to_primary_avg

--- a/models/dynamic_momentum_balance.py
+++ b/models/dynamic_momentum_balance.py
@@ -41,13 +41,6 @@ class NamesAndConstants:
         return "bc_values_mechanics"
 
     @property
-    def vector_valued_mu_lambda(self):
-        subdomain = self.mdg.subdomains(dim=self.nd)[0]
-
-        self.lambda_vector = self.solid.lame_lambda() * np.ones(subdomain.num_cells)
-        self.mu_vector = self.solid.shear_modulus() * np.ones(subdomain.num_cells)
-
-    @property
     def primary_wave_speed(self):
         """Primary wave speed (c_p).
 
@@ -220,7 +213,8 @@ class MySolutionStrategy:
         self.boundary_cells_of_grid = sd.signs_and_cells_of_boundary_faces(
             faces=boundary_faces
         )[1]
-        self.vector_valued_mu_lambda
+
+        self.vector_valued_mu_lambda()
 
         for sd, data in self.mdg.subdomains(return_data=True, dim=self.nd):
             dofs = sd.num_cells
@@ -427,6 +421,17 @@ class MySolutionStrategy:
 
 
 class ConstitutiveLawsDynamicMomentumBalance:
+    def vector_valued_mu_lambda(self) -> None:
+        """Vector representation of mu and lambda.
+
+        Cell-wise representation of the mu and lambda quantities in the rock matrix.
+
+        """
+        subdomain = self.mdg.subdomains(dim=self.nd)[0]
+
+        self.lambda_vector = self.solid.lame_lambda() * np.ones(subdomain.num_cells)
+        self.mu_vector = self.solid.shear_modulus() * np.ones(subdomain.num_cells)
+
     def stiffness_tensor(self, subdomain: pp.Grid) -> pp.FourthOrderTensor:
         """Stiffness tensor [Pa].
 

--- a/utils/utility_functions.py
+++ b/utils/utility_functions.py
@@ -176,7 +176,7 @@ def _symbolic_representation_2D(model, return_dt=False, return_ddt=False):
         )
 
     x, y, t = sym.symbols("x y t")
-    cp = model.primary_wave_speed
+    cp = model.primary_wave_speed(is_scalar=True)
 
     manufactured_sol = model.params.get("manufactured_solution", "bubble")
     if manufactured_sol == "unit_test":
@@ -335,7 +335,7 @@ def _symbolic_representation_3D(model, return_dt=False, return_ddt=False):
         )
 
     x, y, z, t = sym.symbols("x y z t")
-    cp = model.primary_wave_speed
+    cp = model.primary_wave_speed(is_scalar=True)
     manufactured_sol = model.params.get("manufactured_solution", "bubble")
     if manufactured_sol == "bubble":
         u1 = u2 = u3 = t**2 * x * (1 - x) * y * (1 - y) * z * (1 - z)


### PR DESCRIPTION
Hopefully final time in a while that the boundary conditions are refactored. Some unfortunate usage of for-loops made the code significantly slower than the brute force implementations found in PR #10. 

Lacking before the PR will be merged:
* Documentation (will be fixed in separate branch)
* Bugfixes (I don't recall which bugfixes this is supposed to be referring to. Note that I have verification files that run and provide the expected convergence rates in space and time for displacements and tractions)

Additional changes:
* Allow scalar wave speed with use of manufactured solution. A consequence of this is that the wave speeds are not class properties anymore.
* Conform to a recent PorePy update which requires "()" after calling the discretization matrices. That is, they are now methods and not class attributes.
* Readme file has gotten a bullet point list of potential bugs or future problems
* Some enhanced documentation and slightly more widespread usage of type hints